### PR TITLE
Core 2025.1対応

### DIFF
--- a/climate.py
+++ b/climate.py
@@ -4,42 +4,31 @@ import logging
 from homeassistant.core import callback
 from homeassistant.components.climate import ClimateEntity
 from homeassistant.components.climate.const import (
-    DEFAULT_MAX_TEMP,
-    DEFAULT_MIN_TEMP,
-    HVAC_MODE_AUTO,
-    HVAC_MODE_COOL,
-    HVAC_MODE_DRY,
-    HVAC_MODE_FAN_ONLY,
-    HVAC_MODE_HEAT,
-    HVAC_MODE_OFF,
-    SUPPORT_FAN_MODE,
-    SUPPORT_SWING_MODE,
-    SUPPORT_TARGET_TEMPERATURE,
+    HVACMode,
+    ClimateEntityFeature,
 )
-from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS
+from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from . import DOMAIN, CONF_COOL_TEMP, CONF_HEAT_TEMP, NatureRemoBase
 
 _LOGGER = logging.getLogger(__name__)
 
-SUPPORT_FLAGS = SUPPORT_TARGET_TEMPERATURE | SUPPORT_FAN_MODE | SUPPORT_SWING_MODE
+SUPPORT_FLAGS = ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.FAN_MODE | ClimateEntityFeature.SWING_MODE
 
 MODE_HA_TO_REMO = {
-    HVAC_MODE_AUTO: "auto",
-    HVAC_MODE_FAN_ONLY: "blow",
-    HVAC_MODE_COOL: "cool",
-    HVAC_MODE_DRY: "dry",
-    HVAC_MODE_HEAT: "warm",
-    HVAC_MODE_OFF: "power-off",
-}
+    HVACMode.AUTO: "auto",
+    HVACMode.FAN_ONLY: "blow",
+    HVACMode.COOL: "cool",
+    HVACMode.DRY: "dry",
+    HVACMode.HEAT: "warm",
+    HVACMode.OFF: "power-off",}
 
 MODE_REMO_TO_HA = {
-    "auto": HVAC_MODE_AUTO,
-    "blow": HVAC_MODE_FAN_ONLY,
-    "cool": HVAC_MODE_COOL,
-    "dry": HVAC_MODE_DRY,
-    "warm": HVAC_MODE_HEAT,
-    "power-off": HVAC_MODE_OFF,
-}
+    "auto": HVACMode.AUTO,
+    "blow": HVACMode.FAN_ONLY,
+    "cool": HVACMode.COOL,
+    "dry": HVACMode.DRY,
+    "warm": HVACMode.HEAT,
+    "power-off": HVACMode.OFF,}
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
@@ -67,8 +56,8 @@ class NatureRemoAC(NatureRemoBase, ClimateEntity):
         super().__init__(coordinator, appliance)
         self._api = api
         self._default_temp = {
-            HVAC_MODE_COOL: config[CONF_COOL_TEMP],
-            HVAC_MODE_HEAT: config[CONF_HEAT_TEMP],
+            HVACMode.COOL: config[CONF_COOL_TEMP],
+            HVACMode.HEAT: config[CONF_HEAT_TEMP],
         }
         self._modes = appliance["aircon"]["range"]["modes"]
         self._hvac_mode = None
@@ -93,7 +82,7 @@ class NatureRemoAC(NatureRemoBase, ClimateEntity):
     @property
     def temperature_unit(self):
         """Return the unit of measurement which this thermostat uses."""
-        return TEMP_CELSIUS
+        return UnitOfTemperature.CELSIUS
 
     @property
     def min_temp(self):
@@ -138,7 +127,7 @@ class NatureRemoAC(NatureRemoBase, ClimateEntity):
         """Return the list of available operation modes."""
         remo_modes = list(self._modes.keys())
         ha_modes = list(map(lambda mode: MODE_REMO_TO_HA[mode], remo_modes))
-        ha_modes.append(HVAC_MODE_OFF)
+        ha_modes.append(HVACMode.OFF)
         return ha_modes
 
     @property
@@ -183,7 +172,7 @@ class NatureRemoAC(NatureRemoBase, ClimateEntity):
         """Set new target hvac mode."""
         _LOGGER.debug("Set hvac mode: %s", hvac_mode)
         mode = MODE_HA_TO_REMO[hvac_mode]
-        if mode == MODE_HA_TO_REMO[HVAC_MODE_OFF]:
+        if mode == MODE_HA_TO_REMO[HVACMode.OFF]:
             await self._post({"button": mode})
         else:
             data = {"operation_mode": mode}
@@ -225,8 +214,8 @@ class NatureRemoAC(NatureRemoBase, ClimateEntity):
         except:
             self._target_temperature = None
 
-        if ac_settings["button"] == MODE_HA_TO_REMO[HVAC_MODE_OFF]:
-            self._hvac_mode = HVAC_MODE_OFF
+        if ac_settings["button"] == MODE_HA_TO_REMO[HVACMode.OFF]:
+            self._hvac_mode = HVACMode.OFF
         else:
             self._hvac_mode = MODE_REMO_TO_HA[self._remo_mode]
 

--- a/sensor.py
+++ b/sensor.py
@@ -2,17 +2,12 @@
 import logging
 
 from homeassistant.const import (
-    CONF_ACCESS_TOKEN,
-    ENERGY_KILO_WATT_HOUR,
-    POWER_WATT,
-    DEVICE_CLASS_POWER,
-    TEMP_CELSIUS,
-    DEVICE_CLASS_TEMPERATURE,
+    UnitOfPower,
+    UnitOfTemperature,
     PERCENTAGE,
-    DEVICE_CLASS_HUMIDITY,
     LIGHT_LUX,
-    DEVICE_CLASS_ILLUMINANCE,
 )
+from homeassistant.components.sensor.const import SensorDeviceClass
 from . import DOMAIN, NatureRemoBase, NatureRemoDeviceBase
 
 _LOGGER = logging.getLogger(__name__)
@@ -47,7 +42,7 @@ class NatureRemoE(NatureRemoBase):
 
     def __init__(self, coordinator, appliance):
         super().__init__(coordinator, appliance)
-        self._unit_of_measurement = POWER_WATT
+        self._unit_of_measurement = UnitOfPower.WATT
 
     @property
     def state(self):
@@ -69,7 +64,7 @@ class NatureRemoE(NatureRemoBase):
     @property
     def device_class(self):
         """Return the device class."""
-        return DEVICE_CLASS_POWER
+        return SensorDeviceClass.POWER
 
     async def async_added_to_hass(self):
         """Subscribe to updates."""
@@ -100,7 +95,7 @@ class NatureRemoTemperatureSensor(NatureRemoDeviceBase):
     @property
     def unit_of_measurement(self):
         """Return the unit of measurement of this entity, if any."""
-        return TEMP_CELSIUS
+        return UnitOfTemperature.CELSIUS
 
     @property
     def state(self):
@@ -111,7 +106,7 @@ class NatureRemoTemperatureSensor(NatureRemoDeviceBase):
     @property
     def device_class(self):
         """Return the device class."""
-        return DEVICE_CLASS_TEMPERATURE
+        return SensorDeviceClass.TEMPERATURE
 
 
 class NatureRemoHumiditySensor(NatureRemoDeviceBase):
@@ -140,7 +135,7 @@ class NatureRemoHumiditySensor(NatureRemoDeviceBase):
     @property
     def device_class(self):
         """Return the device class."""
-        return DEVICE_CLASS_HUMIDITY
+        return SensorDeviceClass.HUMIDITY
 
 
 class NatureRemoIlluminanceSensor(NatureRemoDeviceBase):
@@ -169,4 +164,4 @@ class NatureRemoIlluminanceSensor(NatureRemoDeviceBase):
     @property
     def device_class(self):
         """Return the device class."""
-        return DEVICE_CLASS_ILLUMINANCE 
+        return SensorDeviceClass.ILLUMINANCE


### PR DESCRIPTION
https://github.com/yutoyazaki/hass-nature-remo/pull/18
を参考（climateはほぼコピー）して、Home Assistant Core 2025.1 のバージョンに対応しました。
2025.1でdeprecatedになった定数変更済みです。

温度は実機があるため動作確認済みですが、湿度と照度センサーは不明です。
